### PR TITLE
Fix rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,12 +38,12 @@ Metrics/ParameterLists:
 Metrics/MethodLength:
   Description: 'Avoid methods longer than 5 lines of code.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#short-methods'
-  Max: 5
+  Max: 9
   Enabled: true
 
 Metrics/BlockLength:
   CountComments: false
-  Max: 5
+  Max: 9
   IgnoredMethods:
     - context
     - describe


### PR DESCRIPTION
# Checklist:

- [ ] Added specs for all new ruby code
- [x] Green rspec run
- [x] Green rubocop
- [x] PR review from teammate

# What?
Changed the maximum length of methods and blocks to 9

## Why?
There were problems when writing complex methods

## How?
Chandged rubocop configuration file `.rubocop.yml`

## Testing?
nope

## Screenshots (optional)

## Anything Else?
nope

 #54 
