### PR TITLE
Fix Bootstrap JS

### DIFF
--- a/app/frontend/js/bootstrap_js_files.js
+++ b/app/frontend/js/bootstrap_js_files.js
@@ -2,7 +2,7 @@
 // import 'bootstrap/js/src/button'
 // import 'bootstrap/js/src/carousel'
 // import 'bootstrap/js/src/collapse'
-// import 'bootstrap/js/src/dropdown'
+import 'bootstrap/js/src/dropdown'
 // import 'bootstrap/js/src/modal'
 // import 'bootstrap/js/src/popover'
 // import 'bootstrap/js/src/scrollspy'

--- a/app/frontend/packs/site.js
+++ b/app/frontend/packs/site.js
@@ -6,7 +6,7 @@
 import Rails from "@rails/ujs"
 import Turbolinks from "turbolinks"
 import * as ActiveStorage from "@rails/activestorage"
-import 'bootstrap' 
+import '../js/bootstrap_js_files.js'
 import "channels"
 
 Rails.start()

--- a/app/frontend/packs/site.js
+++ b/app/frontend/packs/site.js
@@ -6,7 +6,7 @@
 import Rails from "@rails/ujs"
 import Turbolinks from "turbolinks"
 import * as ActiveStorage from "@rails/activestorage"
-import '../js/bootstrap_js_files.js' 
+import 'bootstrap' 
 import "channels"
 
 Rails.start()

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,5 +8,6 @@ html
     = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
+    = javascript_pack_tag 'site', 'data-turbolinks-track': 'reload'
   body
     = yield


### PR DESCRIPTION
# Checklist:

- [x] Added specs for all new ruby code
- [x] Green rspec run
- [x] Green rubocop
- [x] PR review from teammate

# What?
Made Webpacker actually include Bootstrap and other JS code into the bundle, not only CSS "wrappers".

## Why?
Because dropdowns and other interactive components don't work without Bootstrap's JS.

## How?
Moved the JS pack into `app/frontend/packs` instead of `app/frontend/javascript/packs` and renamed it into `site.js` so that it doesn't get confused with the (S)CSS one. `application.html.slim` includes this one too with `javascript_pack_tag`.

## Testing?
Did you write tests? No.

