### PR TITLE
Compile assets on workflow run

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -52,6 +52,10 @@ jobs:
         run: |
           bundler exec rails db:create RAILS_ENV=test
           bundler exec rails db:migrate RAILS_ENV=test
+      - name: Compile assets
+        run: |
+          bundler exec rails assets:precompile
+          bundler exec rails webpacker:compile
       - name: Run tests
         run: bundler exec rake
       - name: Upload coverage results    


### PR DESCRIPTION
# Checklist:

- [x] Added specs for all new ruby code (there was no ruby code)
- [x] Green rspec run
- [x] Green rubocop
- [ ] PR review from teammate

# What?
Made the workflow also compile assets when running.

## Why?
Some specs (mainly in `requests/`) require the server to be runnable and certain endpoints to be reachable. The server can't run without already-built assets - RSpec fails.

## How?
I just added these 2 commands to the workflow:
```bash
bundle exec assets:precompile
bundle exec webpacker:compile
```

## Testing?
Did you write tests? They're not needed.

