### PR TITLE
Fix header on mobile

### DIFF
--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -1,13 +1,12 @@
 header.d-flex.w-100.flex-column
   nav.navbar.navbar-expand-lg.navbar-dark.bg-transparent.container
-    div.collapse.navbar-collapse
-      ul.nav.navbar-nav.me-auto
-        li.nav-item
-          = link_to 'About', '#', class: 'nav-link'
-        li.nav-item
-          = link_to 'Contact', '#', class: 'nav-link'
+    ul.nav.navbar-nav.me-auto
+      li.nav-item
+        = link_to 'About', '#', class: 'nav-link'
+      li.nav-item
+        = link_to 'Contact', '#', class: 'nav-link'
     = link_to "HostMePlease", root_path, class: "navbar-brand mx-auto nav-link"
-    div.collapse.navbar-collapse.userinfo
+    .userinfo
       ul.navbar.navbar-nav.ms-auto
         - if user_signed_in?
           li.nav-item.dropdown


### PR DESCRIPTION
# Checklist:

- [x] Added specs for all new ruby code
- [x] Green rspec run
- [x] Green rubocop
- [x] PR review from teammate

# What?
Made header links not hide on certain 'mobile' devices (tablets and smaller).

## Why?
Because it was straight up unusable on those.

## How?
Removed the `.collapse.navbar-collapse` class from link containers.

## Testing?
Did you write tests? No, I didn't add any Ruby code.
