### PR TITLE
Fix Heroku deploy error

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,8 +18,7 @@ Rails.application.configure do
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
-  config.require_master_key = true
-
+  config.require_master_key = false
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?


### PR DESCRIPTION
# Checklist:

- [x] Added specs for all new ruby code
- [x] Green rspec run
- [x] Green rubocop
- [ ] PR review from teammate

# What?
Made it (probably) not fail when trying to deploy to Heroku.

## Why?
Because it does error right now.

## How?
Removed the master key requirement.

## Testing?
Did you write tests? No.
